### PR TITLE
`SentenceEncoder.device` attribute fix + tests.

### DIFF
--- a/embetter/text/_sbert.py
+++ b/embetter/text/_sbert.py
@@ -71,7 +71,8 @@ class SentenceEncoder(EmbetterBase):
         if not device:
             device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.name = name
-        self.tfm = SBERT(name, device=device)
+        self.device = device
+        self.tfm = SBERT(name, device=self.device)
 
     def transform(self, X, y=None):
         """Transforms the text into a numeric representation."""

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from embetter.text import SentenceEncoder
+
+
+def test_basic_sentence_encoder():
+    encoder = SentenceEncoder()
+    # Embedding dim of underlying model
+    output_dim = encoder.tfm._modules['1'].word_embedding_dimension
+    test_sentences = ["This is a test sentence!", "And this is another one", "\rUnicode stuff: ♣️,♦️,❤️,♠️\n"]
+    output = encoder.fit_transform(test_sentences)
+    assert isinstance(output, np.ndarray)
+    assert output.shape == (len(test_sentences), output_dim)
+    # scikit-learn configures repr dynamically from defined attributes.
+    # To test correct implementation we should test if calling repr breaks.
+    assert repr(encoder)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,11 +4,15 @@ from embetter.text import SentenceEncoder
 
 
 def test_basic_sentence_encoder():
-    """ Check correct dimensions and repr for SentenceEncoder. """
+    """Check correct dimensions and repr for SentenceEncoder."""
     encoder = SentenceEncoder()
     # Embedding dim of underlying model
-    output_dim = encoder.tfm._modules['1'].word_embedding_dimension
-    test_sentences = ["This is a test sentence!", "And this is another one", "\rUnicode stuff: ♣️,♦️,❤️,♠️\n"]
+    output_dim = encoder.tfm._modules["1"].word_embedding_dimension
+    test_sentences = [
+        "This is a test sentence!",
+        "And this is another one",
+        "\rUnicode stuff: ♣️,♦️,❤️,♠️\n",
+    ]
     output = encoder.fit_transform(test_sentences)
     assert isinstance(output, np.ndarray)
     assert output.shape == (len(test_sentences), output_dim)

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,6 +4,7 @@ from embetter.text import SentenceEncoder
 
 
 def test_basic_sentence_encoder():
+    """ Check correct dimensions and repr for SentenceEncoder. """
     encoder = SentenceEncoder()
     # Embedding dim of underlying model
     output_dim = encoder.tfm._modules['1'].word_embedding_dimension


### PR DESCRIPTION
Fixes #33 . 

1. `device` in `SentenceEncoder` is now defined as attribute so it doesn't break in scikit-learn use cases.
2. Tests for `SentenceEncoder`.