### PR TITLE
Sense2Vec sklearn param fix

### DIFF
--- a/embetter/text/_s2v.py
+++ b/embetter/text/_s2v.py
@@ -15,8 +15,9 @@ class Sense2VecEncoder(BaseEstimator):
         path: path to downloaded model
     """
 
-    def __init__(self, path):
-        self.s2v = Sense2Vec().from_disk(path)
+    def __init__(self, path: str):
+        self.path = path
+        self.s2v = Sense2Vec().from_disk(self.path)
 
     def transform(self, X, y=None):
         """Transforms the phrase text into a numeric representation."""


### PR DESCRIPTION
Related to #33. All arguments should be attributes in order for the object to work well with sklearn.