### PR TITLE
feature/allow-pd-series-in-sentence-encoder

### DIFF
--- a/embetter/text/_sbert.py
+++ b/embetter/text/_sbert.py
@@ -1,6 +1,7 @@
 import torch
 from sentence_transformers import SentenceTransformer as SBERT
 from embetter.base import EmbetterBase
+import pandas as pd
 
 
 class SentenceEncoder(EmbetterBase):
@@ -76,4 +77,8 @@ class SentenceEncoder(EmbetterBase):
 
     def transform(self, X, y=None):
         """Transforms the text into a numeric representation."""
+        # Convert pd.Series objects to encode compatable
+        if isinstance(X, pd.Series):
+            X = X.to_numpy()
+
         return self.tfm.encode(X)


### PR DESCRIPTION
Hello!

First I want to say thanks for making this package, it's really useful!

I wanted to be able to do the following:

```python
# Build the pipeline
pipeline = make_pipeline(
    SentenceEncoder("all-MiniLM-L12-v2"),
    LogisticRegressionCV(),
)

# Fit the pipeline
pipeline.fit(train_df["text"], train_df["label"])
```

Instead of using the `ColumnGrabber` simply because I don't want to pass in the whole DataFrame. Just personal preference.

This small change allows for that exact behavior.

Let me know if you disagree with this pattern, I understand if you do. Either way, thanks for making this!