### PR TITLE
Adding UniversalSentenceEncoder for text embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ pipelines as well.
 |:-------------------------:|------------------------------------------------------|--------------------------------------------------------------|
 | `ColumnGrabber`           | [docs](https://koaning.github.io/embetter/API/grab/) | `dataframe` → `ColumnGrabber` → `list with column contents`  |
 | `SentenceEncoder`         | [docs](https://koaning.github.io/embetter/API/text/sentence-enc/) | `list of text` → `SentenceEncoder` → `embedding array`  |
+| `UniversalSentenceEncoder`         | [docs](https://koaning.github.io/embetter/API/text/USE/) | `list of text` → `UniversalSentenceEncoder` → `embedding array`  |
 | `Sense2VecEncoder`        | [docs](https://koaning.github.io/embetter/API/text/sense2vec/)    | `list of text` → `Sense2VecEncoder` → `embedding array` |
 | `spaCyEncoder`        | [docs](https://koaning.github.io/embetter/API/text/spacy/)    | `list of text` → `spaCyEncoder` → `embedding array` |
 | `BytePairEncoder`         | [docs](https://koaning.github.io/embetter/API/text/bytepair/)    | `list of text` → `BytePairEncoder` → `embedding array` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ from embetter.grab import ColumnGrabber
 from embetter.vision import ImageLoader, TimmEncoder, ColorHistogramEncoder
 
 # Representations for text
-from embetter.text import SentenceEncoder, Sense2VecEncoder, BytePairEncoder
+from embetter.text import SentenceEncoder, Sense2VecEncoder, BytePairEncoder, spaCyEncoder
 
 # Finetuning components 
 from embetter.finetune import ForwardFinetuner
@@ -132,8 +132,9 @@ pipelines as well.
 |:-------------------------:|------------------------------------------------------|--------------------------------------------------------------|
 | `ColumnGrabber`           | [docs](https://koaning.github.io/embetter/API/grab/) | `dataframe` → `ColumnGrabber` → `list with column contents`  |
 | `SentenceEncoder`         | [docs](https://koaning.github.io/embetter/API/text/sentence-enc/) | `list of text` → `SentenceEncoder` → `embedding array`  |
+| `UniversalSentenceEncoder`         | [docs](https://koaning.github.io/embetter/API/text/USE/) | `list of text` → `UniversalSentenceEncoder` → `embedding array`  |
 | `Sense2VecEncoder`        | [docs](https://koaning.github.io/embetter/API/text/sense2vec/)    | `list of text` → `Sense2VecEncoder` → `embedding array` |
-| `spaCyEncoder`            | [docs](https://koaning.github.io/embetter/API/text/spacy/)    | `list of text` → `spaCyEncoder` → `embedding array` |
+| `spaCyEncoder`        | [docs](https://koaning.github.io/embetter/API/text/spacy/)    | `list of text` → `spaCyEncoder` → `embedding array` |
 | `BytePairEncoder`         | [docs](https://koaning.github.io/embetter/API/text/bytepair/)    | `list of text` → `BytePairEncoder` → `embedding array` |
 | `ImageLoader`             | [docs](https://koaning.github.io/embetter/API/vision/imageload/) | `list of paths` → `ImageLoader` → `list of PIL images` |
 | `ColorHistogramEncoder`   | [docs](https://koaning.github.io/embetter/API/vision/colorhist/) | `list of PIL images` → `ColorHistogramEncoder` → `embedding array`           |

--- a/embetter/text/__init__.py
+++ b/embetter/text/__init__.py
@@ -20,5 +20,9 @@ try:
 except ModuleNotFoundError:
     spaCyEncoder = NotInstalled("spaCyEncoder", "spacy")
 
+try:
+    from embetter.text._unise import UniversalSentenceEncoder
+except ModuleNotFoundError:
+    UniversalSentenceEncoder = NotInstalled("UniversalSentenceEncoder", "USE")
 
 __all__ = ["SentenceEncoder", "Sense2VecEncoder", "BytePairEncoder", "spaCyEncoder"]

--- a/embetter/text/_unise.py
+++ b/embetter/text/_unise.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import tensorflow as tf
+import tensorflow_hub as hub
+
+from embetter.base import EmbetterBase
+
+
+class UniversalSentenceEncoder(EmbetterBase):
+    """
+    Encoder that can numerically encode sentences.
+
+    Arguments:
+        name: name of model, see available options
+        device: manually override cpu/gpu device, tries to grab gpu automatically when available
+
+    The following model names should be supported:
+
+    - `universal-sentence-encoder/4`
+    - `universal-sentence-encoder-large/5`
+    - `universal-sentence-encoder-multilingual/3`
+    - `universal-sentence-encoder-multilingual-large/3`
+
+    You can find the more options, and information, on the [Universal Sentence Encoder hub tutorial](.https://www.tensorflow.org/hub/tutorials/semantic_similarity_with_tf_hub_universal_encoder#evaluation_sts_semantic_textual_similarity_benchmark)
+
+    **Usage**:
+
+    ```python
+    import pandas as pd
+    from sklearn.pipeline import make_pipeline
+    from sklearn.linear_model import LogisticRegression
+
+    from embetter.grab import ColumnGrabber
+    from embetter.text import
+
+    # Let's suppose this is the input dataframe
+    dataf = pd.DataFrame({
+        "text": ["positive sentiment", "super negative"],
+        "label_col": ["pos", "neg"]
+    })
+
+    # This pipeline grabs the `text` column from a dataframe
+    # which then get fed into Tensorflows' universal-sentence-ecnoder-lite/2.
+    text_emb_pipeline = make_pipeline(
+        ColumnGrabber("text"),
+        UniversalSentenceEncoder('universal-sentence-encoder-lite/2')
+    )
+    X = text_emb_pipeline.fit_transform(dataf, dataf['label_col'])
+
+    # This pipeline can also be trained to make predictions, using
+    # the embedded features.
+    text_clf_pipeline = make_pipeline(
+        text_emb_pipeline,
+        LogisticRegression()
+    )
+
+    # Prediction example
+    text_clf_pipeline.fit(dataf, dataf['label_col']).predict(dataf)
+    ```
+    """
+
+    def __init__(self, name="universal-sentence-encoder/4", device=None):
+        if not device:
+            device = "/GPU:0" if self.__is_gpu_available() else "/CPU:0"
+        self.model_url = f"https://tfhub.dev/google/{name}"
+        self.device = device
+        with tf.device(self.device):
+            self.tfm = hub.load(self.model_url)
+
+    def __repr__(self) -> str:
+        return f"UniversalSentenceEncoder(model_url={self.model_url})"
+
+    def __is_gpu_available(self):
+        gpu_devices = tf.config.list_physical_devices("GPU")
+        if len(gpu_devices) > 0:
+            return True
+        else:
+            return False
+
+    def transform(self, X, y=None):
+        """Transforms the text into a numeric representation."""
+        # Convert pd.Series objects to encode compatable
+        if isinstance(X, pd.Series):
+            X = X.to_numpy()
+
+        with tf.device(self.device):
+            sentence_embeddings = self.tfm(X)
+
+        return sentence_embeddings.numpy()

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ sentence_encoder_pkgs = ["sentence-transformers>=2.2.2"]
 sense2vec_pkgs = ["sense2vec==2.0.0"]
 bpemb_packages = ["bpemb>=0.3.3"]
 spacy_packages = ["spacy>=3.5.0"]
+tensorflow_packages = ["tensorflow>=2.9.1", "tensorflow_hub>=0.13.0"]
 
-text_packages = sentence_encoder_pkgs + sense2vec_pkgs + bpemb_packages
+text_packages = (
+    sentence_encoder_pkgs + sense2vec_pkgs + bpemb_packages + tensorflow_packages
+)
 
 vision_packages = ["timm>=0.6.7"]
 
@@ -60,6 +63,7 @@ setup(
         "sense2vec": sense2vec_pkgs + base_packages,
         "sentence-tfm": sentence_encoder_pkgs + base_packages,
         "spacy": spacy_packages + base_packages,
+        "USE": tensorflow_packages + base_packages,
         "bpemb": bpemb_packages + base_packages,
         "text": text_packages + base_packages,
         "vision": vision_packages + base_packages,

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,7 +4,12 @@ import numpy as np
 from spacy.vocab import Vocab
 from spacy.language import Language
 
-from embetter.text import SentenceEncoder, BytePairEncoder, spaCyEncoder
+from embetter.text import (
+    SentenceEncoder,
+    BytePairEncoder,
+    spaCyEncoder,
+    UniversalSentenceEncoder,
+)
 
 
 test_sentences = [
@@ -64,6 +69,18 @@ def test_basic_spacy(setting, nlp):
     output = encoder.fit_transform(test_sentences)
     assert isinstance(output, np.ndarray)
     assert output.shape == (len(test_sentences), 4 if setting == "both" else 2)
+    # scikit-learn configures repr dynamically from defined attributes.
+    # To test correct implementation we should test if calling repr breaks.
+    assert repr(encoder)
+
+
+def test_universal_sentence_encoder():
+    """Check correct dimensions and repr for SentenceEncoder."""
+    encoder = UniversalSentenceEncoder()
+    # Embedding dim of underlying model
+    output = encoder.fit_transform(test_sentences)
+    assert isinstance(output, np.ndarray)
+    assert output.shape == (len(test_sentences), 512)
     # scikit-learn configures repr dynamically from defined attributes.
     # To test correct implementation we should test if calling repr breaks.
     assert repr(encoder)


### PR DESCRIPTION
This PR adds the `Universal Sentence Encoder (USE)` method for text embedding, complementing existing methods. The implementation uses TensorFlow and TensorFlowHub to generate embeddings. Due to compatibility limitations scikit-learn's`BaseEstimator`, the new method has its own `__repr__` method.

Please, review the changes and let me know if there are any suggestions or concerns.