### PR TITLE
typo fix and deprecation warning for MatrouskaEncoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ from embetter.grab import ColumnGrabber
 from embetter.vision import ImageLoader, TimmEncoder, ColorHistogramEncoder
 
 # Representations for text
-from embetter.text import SentenceEncoder, MatrouskaEncoder, Sense2VecEncoder, BytePairEncoder, spaCyEncoder, GensimEncoder
+from embetter.text import SentenceEncoder, MatryoshkaEncoder, Sense2VecEncoder, BytePairEncoder, spaCyEncoder, GensimEncoder
 
 # Representations from multi-modal models
 from embetter.multi import ClipEncoder

--- a/docs/API/text.md
+++ b/docs/API/text.md
@@ -4,9 +4,9 @@
     options:
         members: false
 
-## MatrouskaEncoder
+## MatryoshkaEncoder
 
-::: embetter.text.MatrouskaEncoder
+::: embetter.text.MatryoshkaEncoder
     options:
         members: false
 
@@ -39,7 +39,6 @@
 ::: embetter.text.BytePairEncoder
     options:
         members: false
-
 
 ## GensimEncoder
 

--- a/embetter/text/__init__.py
+++ b/embetter/text/__init__.py
@@ -1,5 +1,5 @@
 from embetter.error import NotInstalled
-from embetter.text._sbert import SentenceEncoder, MatrouskaEncoder
+from embetter.text._sbert import SentenceEncoder, MatrouskaEncoder, MatryoshkaEncoder
 
 try:
     from embetter.text._s2v import Sense2VecEncoder
@@ -33,6 +33,7 @@ from embetter.text._lite import LiteTextEncoder, learn_lite_text_embeddings
 __all__ = [
     "SentenceEncoder",
     "MatrouskaEncoder",
+    "MatryoshkaEncoder"
     "Sense2VecEncoder",
     "BytePairEncoder",
     "spaCyEncoder",

--- a/embetter/text/_sbert.py
+++ b/embetter/text/_sbert.py
@@ -112,9 +112,9 @@ def MatryoshkaEncoder(name="tomaarsen/mpnet-base-nli-matryoshka", **kwargs):
     Encoder that can numerically encode sentences.
 
     This function, which looks like a class, offers a shorthand way to fetch pretrained
-    [Matrouska embeddings](https://www.sbert.net/examples/training/matryoshka/README.html).
+    [Matryoshka embeddings](https://www.sbert.net/examples/training/matryoshka/README.html).
     Under the hood it just returns a `SentenceEncoder` object, but the default name points
-    to a pretrained Matrouska model.
+    to a pretrained Matryoshka model.
 
     These embeddings are more flexible in the sense that you can more easily reduce the
     dimensions without losing as much information. The aforementioned docs give more details
@@ -139,7 +139,7 @@ def MatryoshkaEncoder(name="tomaarsen/mpnet-base-nli-matryoshka", **kwargs):
     # which then get fed into Sentence-Transformers' all-MiniLM-L6-v2.
     text_emb_pipeline = make_pipeline(
         ColumnGrabber("text"),
-        MatrouskaEncoder()
+        MatryoshkaEncoder()
     )
     X = text_emb_pipeline.fit_transform(dataf, dataf['label_col'])
 

--- a/embetter/text/_sbert.py
+++ b/embetter/text/_sbert.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 import pandas as pd
 import torch
 from torch.nn import Linear
@@ -97,6 +99,15 @@ class SentenceEncoder(EmbetterBase):
 
 
 def MatrouskaEncoder(name="tomaarsen/mpnet-base-nli-matryoshka", **kwargs):
+    warn(
+        "Please use `MatryoshkaEncoder` instead of `MatrouskaEncoder."
+        "We will use correct spelling going forward and `MatrouskaEncoder` will be deprecated.",
+        DeprecationWarning,
+    )
+    return MatryoshkaEncoder(name="tomaarsen/mpnet-base-nli-matryoshka", **kwargs)
+
+
+def MatryoshkaEncoder(name="tomaarsen/mpnet-base-nli-matryoshka", **kwargs):
     """
     Encoder that can numerically encode sentences.
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -13,7 +13,7 @@ from embetter.text import (
     SentenceEncoder,
     GensimEncoder,
     spaCyEncoder,
-    MatrouskaEncoder,
+    MatryoshkaEncoder,
     learn_lite_text_embeddings,
     LiteTextEncoder,
 )
@@ -47,7 +47,7 @@ def test_word2vec(setting):
     assert repr(encoder)
 
 
-@pytest.mark.parametrize("encoder", [MatrouskaEncoder, SentenceEncoder])
+@pytest.mark.parametrize("encoder", [MatryoshkaEncoder, SentenceEncoder])
 def test_basic_sentence_encoder(encoder):
     """Check correct dimensions and repr for SentenceEncoder."""
     enc = encoder()


### PR DESCRIPTION
I added deprecation warning using warn, because I noticed this solution in sklego (KlusterFoldValidation). If you prefer me to use deprecated-decorator, just let me know. Not sure if I changed __init__ correctly but they made importing MatryoshkaEncoder possible.