### PR TITLE
comma added in embetter/text/__init_.py fixes #101

### DIFF
--- a/embetter/text/__init__.py
+++ b/embetter/text/__init__.py
@@ -33,7 +33,7 @@ from embetter.text._lite import LiteTextEncoder, learn_lite_text_embeddings
 __all__ = [
     "SentenceEncoder",
     "MatrouskaEncoder",
-    "MatryoshkaEncoder"
+    "MatryoshkaEncoder",
     "Sense2VecEncoder",
     "BytePairEncoder",
     "spaCyEncoder",


### PR DESCRIPTION
fixed the comma
btw
I was curious about the ruff pre-commit hooks. You have that in sklego, I wondered why not here. I mean if there is a reason or just not yet. If not yet, then that might be something I would like to try to do. 