### PR TITLE
Auto-detect MPS availability when using SentenceEncoder or ClipEncoder

### DIFF
--- a/embetter/multi/_clip.py
+++ b/embetter/multi/_clip.py
@@ -15,7 +15,7 @@ class ClipEncoder(EmbetterBase):
 
     Arguments:
         name: name of model, see available options
-        device: manually override cpu/gpu device, tries to grab gpu automatically when available
+        device: manually override cpu/mps/gpu device, tries to grab gpu or mps automatically when available
         quantize: turns on quantization
         num_threads: number of treads for pytorch to use, only affects when device=cpu
 
@@ -31,7 +31,12 @@ class ClipEncoder(EmbetterBase):
         self, name="clip-ViT-B-32", device=None, quantize=False, num_threads=None
     ):
         if not device:
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            if torch.cuda.is_available():
+                device = torch.device("cuda")
+            elif torch.backends.mps.is_available():
+                device = torch.device("mps")
+            else:
+                device = torch.device("cpu")
         self.name = name
         self.device = device
         self.tfm = SBERT(name, device=self.device)

--- a/embetter/text/_sbert.py
+++ b/embetter/text/_sbert.py
@@ -15,7 +15,7 @@ class SentenceEncoder(EmbetterBase):
 
     Arguments:
         name: name of model, see available options
-        device: manually override cpu/gpu device, tries to grab gpu automatically when available
+        device: manually override cpu/mps/gpu device, tries to grab gpu or mps automatically when available
         quantize: turns on quantization
         num_threads: number of treads for pytorch to use, only affects when device=cpu
 
@@ -77,7 +77,12 @@ class SentenceEncoder(EmbetterBase):
         self, name="all-MiniLM-L6-v2", device=None, quantize=False, num_threads=None
     ):
         if not device:
-            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+            if torch.cuda.is_available():
+                device = torch.device("cuda")
+            elif torch.backends.mps.is_available():
+                device = torch.device("mps")
+            else:
+                device = torch.device("cpu")
         self.name = name
         self.device = device
         self.tfm = SBERT(name, device=self.device)


### PR DESCRIPTION
This small PR sets the torch device in `SentenceEncoder` to `mps` whenever CUDA is not available, but MPS is. This speeds up inference on newer Macs, and doesn't affect other device.

Running the following script
```python
from embetter.text import SentenceEncoder
from sklearn.datasets import fetch_20newsgroups

encoder = SentenceEncoder("all-MiniLM-L6-v2")
cats = ["alt.atheism", "sci.space"]
newsgroups_train = fetch_20newsgroups(subset="train", categories=cats)
embeddings = encoder.fit_transform(newsgroups_train["data"])
```
on my M3 MacBook Air with 16 GB of RAM takes ~10 seconds with the changes in this PR (and activates the GPU, according to `mactop`), and ~15 seconds without.

