### PR TITLE
Add `AzureOpenAIEncoder`

### DIFF
--- a/docs/API/external.md
+++ b/docs/API/external.md
@@ -4,6 +4,11 @@
     options:
         members: false
 
+## AzureOpenAIEncoder
+::: embetter.external.AzureOpenAIEncoder
+    options:
+        members: false
+
 ## `CohereEncoder`
 
 ::: embetter.external.CohereEncoder

--- a/embetter/external/__init__.py
+++ b/embetter/external/__init__.py
@@ -1,9 +1,13 @@
 from embetter.error import NotInstalled
 
 try:
-    from ._openai import AzureOpenAIEncoder, OpenAIEncoder
+    from ._openai import OpenAIEncoder
 except ModuleNotFoundError:
     OpenAIEncoder = NotInstalled("OpenAIEncoder", "openai")
+
+try:
+    from ._openai import AzureOpenAIEncoder
+except ModuleNotFoundError:
     AzureOpenAIEncoder = NotInstalled("AzureOpenAIEncoder", "openai")
 
 try:

--- a/embetter/external/__init__.py
+++ b/embetter/external/__init__.py
@@ -1,9 +1,10 @@
 from embetter.error import NotInstalled
 
 try:
-    from ._openai import OpenAIEncoder
+    from ._openai import AzureOpenAIEncoder, OpenAIEncoder
 except ModuleNotFoundError:
     OpenAIEncoder = NotInstalled("OpenAIEncoder", "openai")
+    AzureOpenAIEncoder = NotInstalled("AzureOpenAIEncoder", "openai")
 
 try:
     from ._cohere import CohereEncoder
@@ -11,4 +12,4 @@ except ModuleNotFoundError:
     CohereEncoder = NotInstalled("CohereEncoder", "cohere")
 
 
-__all__ = ["CohereEncoder", "OpenAIEncoder"]
+__all__ = ["CohereEncoder", "OpenAIEncoder", "AzureOpenAIEncoder"]


### PR DESCRIPTION
This small PR introduces a new encoder specifically for Azure OpenAI embeddings #115 . The primary difference from the OpenAIEncoder is the client utilized to interact with the service, other than that it is the same.

